### PR TITLE
Added basic support for SSL/TLS1.0

### DIFF
--- a/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Sockets.Plugin.Abstractions;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Sockets.Plugin
 {
@@ -17,6 +18,7 @@ namespace Sockets.Plugin
     public class TcpSocketClient : ITcpSocketClient
     {
         private readonly TcpClient _backingTcpClient;
+        private SslStream _secureStream;
 
         /// <summary>
         ///     Default constructor for <code>TcpSocketClient</code>.
@@ -36,10 +38,40 @@ namespace Sockets.Plugin
         /// </summary>
         /// <param name="address">The address of the endpoint to connect to.</param>
         /// <param name="port">The port of the endpoint to connect to.</param>
-        public async Task ConnectAsync(string address, int port)
+        /// <param name="secure">Is this connection secure?</param>
+        public async Task ConnectAsync(string address, int port, bool secure = false)
         {
             await _backingTcpClient.ConnectAsync(address, port);
+            if (!secure)
+            {
+                _secureStream = new SslStream(_backingTcpClient.GetStream(), true, (sender, cert, chain, sslPolicy) => ServerValidationCallback(sender,cert,chain,sslPolicy));
+                _secureStream.AuthenticateAsClient(address, null, System.Security.Authentication.SslProtocols.Tls, false);
+            }            
         }
+
+        #region Secure Sockets Details
+        
+        private bool ServerValidationCallback (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        {
+            switch (sslPolicyErrors)
+            {
+                case SslPolicyErrors.RemoteCertificateNameMismatch:
+                    Console.WriteLine("Server name mismatch. End communication ...\n");
+                    return false;
+                case SslPolicyErrors.RemoteCertificateNotAvailable:
+                    Console.WriteLine("Server's certificate not available. End communication ...\n");
+                    return false;
+                case SslPolicyErrors.RemoteCertificateChainErrors:
+                    Console.WriteLine("Server's certificate validation failed. End communication ...\n");
+                    return false;
+            }
+            //TODO: Perform others checks using the "certificate" and "chain" objects ...
+
+            Console.WriteLine("Server's authentication succeeded ...\n");
+            return true;
+        }
+
+        #endregion
 
         /// <summary>
         ///     Disconnects from an endpoint previously connected to using <code>ConnectAsync</code>.
@@ -55,7 +87,14 @@ namespace Sockets.Plugin
         /// </summary>
         public Stream ReadStream
         {
-            get { return _backingTcpClient.GetStream(); }
+            get
+            {
+                if (_secureStream != null)
+                {
+                    return _secureStream;
+                }
+                return _backingTcpClient.GetStream();
+            }
         }
 
         /// <summary>
@@ -63,7 +102,14 @@ namespace Sockets.Plugin
         /// </summary>
         public Stream WriteStream
         {
-            get { return _backingTcpClient.GetStream(); }
+            get
+            {
+                if (_secureStream != null)
+                {
+                    return _secureStream;
+                }
+                return _backingTcpClient.GetStream();
+            }
         }
 
         private IPEndPoint RemoteEndpoint

--- a/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
@@ -38,12 +38,19 @@ namespace Sockets.Plugin
         /// </summary>
         /// <param name="address">The address of the endpoint to connect to.</param>
         /// <param name="port">The port of the endpoint to connect to.</param>
-        public async Task ConnectAsync(string address, int port)
+        public async Task ConnectAsync(string address, int port, bool secure = false)
         {
             var hn = new HostName(address);
             var sn = port.ToString();
 
-            await _backingStreamSocket.ConnectAsync(hn, sn);
+            if (!secure)
+            {
+                await _backingStreamSocket.ConnectAsync(hn, sn);
+            }
+            else
+            {
+                await _backingStreamSocket.ConnectAsync(hn, sn, SocketProtectionLevel.Tls10);
+            }
         }
 
         /// <summary>

--- a/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
@@ -43,14 +43,7 @@ namespace Sockets.Plugin
             var hn = new HostName(address);
             var sn = port.ToString();
 
-            if (!secure)
-            {
-                await _backingStreamSocket.ConnectAsync(hn, sn);
-            }
-            else
-            {
-                await _backingStreamSocket.ConnectAsync(hn, sn, SocketProtectionLevel.Tls10);
-            }
+            await _backingStreamSocket.ConnectAsync(hn, sn, secure ? SocketProtectionLevel.Tls10 : SocketProtectionLevel.PlainSocket);
         }
 
         /// <summary>

--- a/Sockets/Sockets.Plugin.Abstractions/ITcpSocketClient.cs
+++ b/Sockets/Sockets.Plugin.Abstractions/ITcpSocketClient.cs
@@ -17,7 +17,8 @@ namespace Sockets.Plugin.Abstractions
         /// </summary>
         /// <param name="address">The address of the endpoint to connect to.</param>
         /// <param name="port">The port of the endpoint to connect to.</param>
-        Task ConnectAsync(string address, int port);
+        /// <param name="secure">Is this socket secure?</param>
+        Task ConnectAsync(string address, int port, bool secure = false);
 
         /// <summary>
         ///     Disconnects from an endpoint previously connected to using <code>ConnectAsync</code>.

--- a/Sockets/Sockets.Plugin/TcpSocketClient.cs
+++ b/Sockets/Sockets.Plugin/TcpSocketClient.cs
@@ -18,7 +18,8 @@ namespace Sockets.Plugin
         /// </summary>
         /// <param name="address">The address of the endpoint to connect to.</param>
         /// <param name="port">The port of the endpoint to connect to.</param>
-        public Task ConnectAsync(string address, int port)
+        /// <param name="secure">Is this socket secure?</param>
+        public Task ConnectAsync(string address, int port, bool secure = false)
         {
             throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
         }


### PR DESCRIPTION
Added basic support for SSL/TLS1.0 Secure sockets. Just pass true on secure parameter at TcpSocketClient.ConnectAsync() and it will do the show. Note that it will requires the server to support it too, and no client certificate implementation is done yet. Using it, makes all communication between server and client will be encrypted.