### PR TITLE
Prevents fatal exception on calling DisconnectAsync

### DIFF
--- a/Sockets/Sockets.Implementation.WinRT/UdpSocketBase.cs
+++ b/Sockets/Sockets.Implementation.WinRT/UdpSocketBase.cs
@@ -95,7 +95,13 @@ namespace Sockets.Plugin
         {
             await Task.Run(() =>
             {
-                _backingDatagramSocket.MessageReceived -= DatagramMessageReceived;
+                try
+                {
+                    _backingDatagramSocket.MessageReceived -= DatagramMessageReceived;
+                }
+                catch (Exception)
+                {
+                }
                 _backingDatagramSocket.Dispose();
                 SetBackingSocket();
             });


### PR DESCRIPTION
This line (Windows Store):

_backingDatagramSocket.MessageReceived -= DatagramMessageReceived;

causes this exception (not throwing in NuGet package at all):

A method was called at an unexpected time.

and will result in very unexpected behaviors in the next operations
(even other TCP, UDP calls).
Wrapping it in a try catch will resolve this problem by handling the
exception. The root cause still to be determined.