### PR TITLE
Async improvements

### DIFF
--- a/Sockets.Plugin.nuspec
+++ b/Sockets.Plugin.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="2.8.1">
     <id>rda.SocketsForPCL</id>
-    <version>1.1.7</version>
+    <version>1.1.8-pre</version>
     <title>Sockets Plugin for Xamarin and Windows (PCL)</title>
     <authors>Ryan Davis</authors>
     <owners>Ryan Davis</owners>

--- a/Sockets/Sockets.Implementation.NET/CommsInterface.cs
+++ b/Sockets/Sockets.Implementation.NET/CommsInterface.cs
@@ -123,9 +123,9 @@ namespace Sockets.Plugin
         /// Retrieves information on the IPv4 network interfaces available.
         /// </summary>
         /// <returns></returns>
-        public static async Task<List<CommsInterface>> GetAllInterfacesAsync()
+        public static Task<List<CommsInterface>> GetAllInterfacesAsync()
         {
-            var interfaces = await Task.Run(() =>
+            var interfaces = Task.Run(() =>
                 System.Net.NetworkInformation.NetworkInterface
                     .GetAllNetworkInterfaces()
                     .Select(FromNativeInterface)

--- a/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
@@ -78,9 +78,9 @@ namespace Sockets.Plugin
         ///     Disconnects from an endpoint previously connected to using <code>ConnectAsync</code>.
         ///     Should not be called on a <code>TcpSocketClient</code> that is not already connected.
         /// </summary>
-        public async Task DisconnectAsync()
+        public Task DisconnectAsync()
         {
-            await Task.Run(() => {
+            return Task.Run(() => {
                 _backingTcpClient.Close();
                 _secureStream = null;
             });

--- a/Sockets/Sockets.Implementation.NET/TcpSocketListener.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketListener.cs
@@ -32,9 +32,9 @@ namespace Sockets.Plugin
         /// <param name="port">The port to listen on.</param>
         /// <param name="listenOn">The <code>CommsInterface</code> to listen on. If unspecified, all interfaces will be bound.</param>
         /// <returns></returns>
-        public async Task StartListeningAsync(int port, ICommsInterface listenOn = null)
+        public Task StartListeningAsync(int port, ICommsInterface listenOn = null)
         {
-            await Task.Run(() =>
+            return Task.Run(() =>
             {
                 if (listenOn != null && !listenOn.IsUsable)
                     throw new InvalidOperationException("Cannot listen on an unusable interface. Check the IsUsable property before attemping to bind.");
@@ -54,9 +54,9 @@ namespace Sockets.Plugin
         ///     Stops the <code>TcpSocketListener</code> from listening for new TCP connections.
         ///     This does not disconnect existing connections.
         /// </summary>
-        public async Task StopListeningAsync()
+        public Task StopListeningAsync()
         {
-            await Task.Run(
+            return Task.Run(
                 () =>
                 {
                     _listenCanceller.Cancel();

--- a/Sockets/Sockets.Implementation.NET/UdpSocketBase.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketBase.cs
@@ -67,9 +67,9 @@ namespace Sockets.Plugin
         ///     There may be no 'default' target. depending on the state of the object.
         /// </summary>
         /// <param name="data">A byte array of data to be sent.</param>
-        protected async Task SendAsync(byte[] data)
+        protected Task SendAsync(byte[] data)
         {
-            await _backingUdpClient.SendAsync(data, data.Length);
+            return _backingUdpClient.SendAsync(data, data.Length);
         }
 
         /// <summary>
@@ -78,9 +78,9 @@ namespace Sockets.Plugin
         /// <param name="data">A byte array of data to send.</param>
         /// <param name="address">The remote address to which the data should be sent.</param>
         /// <param name="port">The remote port to which the data should be sent.</param>
-        protected async Task SendToAsync(byte[] data, string address, int port)
+        protected Task SendToAsync(byte[] data, string address, int port)
         {
-            await _backingUdpClient.SendAsync(data, data.Length, address, port);
+            return _backingUdpClient.SendAsync(data, data.Length, address, port);
         }
         
         /// <summary>

--- a/Sockets/Sockets.Implementation.NET/UdpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketClient.cs
@@ -34,20 +34,20 @@ namespace Sockets.Plugin
         /// </summary>
         /// <param name="address">The remote address for the default target.</param>
         /// <param name="port">The remote port for the default target.</param>
-        public async Task ConnectAsync(string address, int port)
+        public Task ConnectAsync(string address, int port)
         {
             _messageCanceller = new CancellationTokenSource();
 
-            await Task.Run(() => _backingUdpClient.Connect(address, port));
+            return Task.Run(() => _backingUdpClient.Connect(address, port));
         }
 
         /// <summary>
         ///     Unsets the 'default' target of sent data.
         ///     After calling <code>DisconnectAsync</code>, calls to <code>SendAsync</code> will have no effect.
         /// </summary>
-        public async Task DisconnectAsync()
+        public Task DisconnectAsync()
         {
-            await Task.Run(() =>
+            return Task.Run(() =>
             {
                 _messageCanceller.Cancel();
                 _backingUdpClient.Close();
@@ -60,9 +60,9 @@ namespace Sockets.Plugin
         ///     If the 'default' target has not been set, calls will have no effect.
         /// </summary>
         /// <param name="data">A byte array of data to be sent.</param>
-        public new async Task SendAsync(byte[] data)
+        public new Task SendAsync(byte[] data)
         {
-            await base.SendAsync(data);
+            return base.SendAsync(data);
         }
 
         /// <summary>
@@ -71,9 +71,9 @@ namespace Sockets.Plugin
         /// <param name="data">A byte array of data to send.</param>
         /// <param name="address">The remote address to which the data should be sent.</param>
         /// <param name="port">The remote port to which the data should be sent.</param>
-        public new async Task SendToAsync(byte[] data, string address, int port)
+        public new Task SendToAsync(byte[] data, string address, int port)
         {
-            await base.SendToAsync(data, address, port);
+            return base.SendToAsync(data, address, port);
         }
     }
 }

--- a/Sockets/Sockets.Implementation.NET/UdpSocketMulticastClient.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketMulticastClient.cs
@@ -56,9 +56,9 @@ namespace Sockets.Plugin
         /// <summary>
         ///     Removes the <code>UdpSocketMulticastClient</code> from a joined multicast group.
         /// </summary>
-        public async Task DisconnectAsync()
+        public Task DisconnectAsync()
         {
-            await Task.Run(() =>
+            return Task.Run(() =>
             {
                 _messageCanceller.Cancel();
                 _backingUdpClient.Close();
@@ -83,12 +83,12 @@ namespace Sockets.Plugin
         ///     If a group has not been set, calls will have no effect.
         /// </summary>
         /// <param name="data">A byte array of data to be sent.</param>
-        public async Task SendMulticastAsync(byte[] data)
+        public Task SendMulticastAsync(byte[] data)
         {
             if (_multicastAddress == null)
                 throw new InvalidOperationException("Must join a multicast group before sending.");
 
-            await base.SendToAsync(data, _multicastAddress, _multicastPort);
+            return base.SendToAsync(data, _multicastAddress, _multicastPort);
         }
 
         /// <summary>

--- a/Sockets/Sockets.Implementation.NET/UdpSocketReceiver.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketReceiver.cs
@@ -22,12 +22,12 @@ namespace Sockets.Plugin
         /// <param name="port">The port to listen on. If '0', selection is delegated to the operating system.</param>        
         /// <param name="listenOn">The <code>CommsInterface</code> to listen on. If unspecified, all interfaces will be bound.</param>
         /// <returns></returns>
-        public async Task StartListeningAsync(int port = 0, ICommsInterface listenOn = null)
+        public Task StartListeningAsync(int port = 0, ICommsInterface listenOn = null)
         {
             if (listenOn != null && !listenOn.IsUsable)
                 throw new InvalidOperationException("Cannot listen on an unusable interface. Check the IsUsable property before attemping to bind.");
 
-            await Task.Run(() =>
+            return Task.Run(() =>
             {
                 var ip = listenOn != null ? ((CommsInterface)listenOn).NativeIpAddress : IPAddress.Any;
                 var ep = new IPEndPoint(ip, port);
@@ -46,9 +46,9 @@ namespace Sockets.Plugin
         ///     Unbinds a bound <code>UdpSocketServer</code>. Should not be called if the <code>UdpSocketServer</code> has not yet
         ///     been unbound.
         /// </summary>
-        public async Task StopListeningAsync()
+        public Task StopListeningAsync()
         {
-            await Task.Run(() =>
+            return Task.Run(() =>
             {
                 _messageCanceller.Cancel();
                 _backingUdpClient.Close();

--- a/Sockets/Sockets.Implementation.WinRT/CommsInterface.cs
+++ b/Sockets/Sockets.Implementation.WinRT/CommsInterface.cs
@@ -80,9 +80,9 @@ namespace Sockets.Plugin
         /// Retrieves information on the IPv4 network interfaces available.
         /// </summary>
         /// <returns></returns>
-        public static async Task<List<CommsInterface>> GetAllInterfacesAsync()
+        public static Task<List<CommsInterface>> GetAllInterfacesAsync()
         {
-            return await Task.Run(() =>
+            return Task.Run(() =>
             {
                 var profiles = NetworkInformation
                     .GetConnectionProfiles()

--- a/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
@@ -30,7 +30,6 @@ namespace Sockets.Plugin
         public TcpSocketClient()
         {
             _backingStreamSocket = new StreamSocket();
-            ;
         }
 
         internal TcpSocketClient(StreamSocket nativeSocket)
@@ -44,22 +43,22 @@ namespace Sockets.Plugin
         /// <param name="address">The address of the endpoint to connect to.</param>
         /// <param name="port">The port of the endpoint to connect to.</param>
         /// <param name="secure">True to enable TLS on the socket.</param>
-        public async Task ConnectAsync(string address, int port, bool secure = false)
+        public Task ConnectAsync(string address, int port, bool secure = false)
         {
             var hn = new HostName(address);
             var sn = port.ToString();
             var spl = secure ? _secureSocketProtectionLevel : SocketProtectionLevel.PlainSocket;
 
-            await _backingStreamSocket.ConnectAsync(hn, sn, spl);
+            return _backingStreamSocket.ConnectAsync(hn, sn, spl).AsTask();
         }
 
         /// <summary>
         ///     Disconnects from an endpoint previously connected to using <code>ConnectAsync</code>.
         ///     Should not be called on a <code>TcpSocketClient</code> that is not already connected.
         /// </summary>
-        public async Task DisconnectAsync()
+        public Task DisconnectAsync()
         {
-            await Task.Run(() => _backingStreamSocket.Dispose());
+            return Task.Run(() => _backingStreamSocket.Dispose());
         }
 
         /// <summary>

--- a/Sockets/Sockets.Implementation.WinRT/TcpSocketListener.cs
+++ b/Sockets/Sockets.Implementation.WinRT/TcpSocketListener.cs
@@ -31,7 +31,7 @@ namespace Sockets.Plugin
         /// <param name="port">The port to listen on.</param>
         /// <param name="listenOn">The <code>CommsInterface</code> to listen on. If unspecified, all interfaces will be bound.</param>
         /// <returns></returns>
-        public async Task StartListeningAsync(int port, ICommsInterface listenOn = null)
+        public Task StartListeningAsync(int port, ICommsInterface listenOn = null)
         {
             if (listenOn != null && !listenOn.IsUsable)
                 throw new InvalidOperationException("Cannot listen on an unusable interface. Check the IsUsable property before attemping to bind.");
@@ -53,21 +53,21 @@ namespace Sockets.Plugin
             if (listenOn != null)
             {
                 var adapter = ((CommsInterface) listenOn).NativeNetworkAdapter;
-  
-                await _backingStreamSocketListener.BindServiceNameAsync(port.ToString(), SocketProtectionLevel.PlainSocket, adapter);
+
+                return _backingStreamSocketListener.BindServiceNameAsync(port.ToString(), SocketProtectionLevel.PlainSocket, adapter).AsTask();
             }
             else
 #endif
-                await _backingStreamSocketListener.BindServiceNameAsync(port.ToString());
+                return _backingStreamSocketListener.BindServiceNameAsync(port.ToString()).AsTask();
         }
         
         /// <summary>
         ///     Stops the <code>TcpSocketListener</code> from listening for new tcp connections.
         ///     This does not disconnect existing connections.
         /// </summary>
-        public async Task StopListeningAsync()
+        public Task StopListeningAsync()
         {   
-            await Task.Run(() =>
+            return Task.Run(() =>
             {
                 _listenCanceller.Cancel();
                 _backingStreamSocketListener.Dispose();

--- a/Sockets/Sockets.Implementation.WinRT/UdpSocketBase.cs
+++ b/Sockets/Sockets.Implementation.WinRT/UdpSocketBase.cs
@@ -39,7 +39,6 @@ namespace Sockets.Plugin
             socket.MessageReceived += DatagramMessageReceived;
 
             _backingDatagramSocket = socket;
-            ;
         }
 
         /// <summary>
@@ -91,9 +90,9 @@ namespace Sockets.Plugin
                 MessageReceived(this, wrapperArgs);
         }
 
-        internal async Task CloseSocketAsync()
+        internal Task CloseSocketAsync()
         {
-            await Task.Run(() =>
+            return Task.Run(() =>
             {
                 _backingDatagramSocket.MessageReceived -= DatagramMessageReceived;
                 _backingDatagramSocket.Dispose();

--- a/Sockets/Sockets.Implementation.WinRT/UdpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.WinRT/UdpSocketClient.cs
@@ -21,21 +21,21 @@ namespace Sockets.Plugin
         /// </summary>
         /// <param name="address">The remote address for the default target.</param>
         /// <param name="port">The remote port for the default target.</param>
-        public async Task ConnectAsync(string address, int port)
+        public Task ConnectAsync(string address, int port)
         {
             var hn = new HostName(address);
             var sn = port.ToString();
 
-            await _backingDatagramSocket.ConnectAsync(hn, sn);
+            return _backingDatagramSocket.ConnectAsync(hn, sn).AsTask();
         }
 
         /// <summary>
         ///     Unsets the 'default' target of sent data.
         ///     After calling <code>DisconnectAsync</code>, calls to <code>SendAsync</code> will have no effect.
         /// </summary>
-        public async Task DisconnectAsync()
+        public Task DisconnectAsync()
         {
-            await CloseSocketAsync();
+            return CloseSocketAsync();
         }
 
         /// <summary>
@@ -44,9 +44,9 @@ namespace Sockets.Plugin
         ///     If the 'default' target has not been set, calls will have no effect.
         /// </summary>
         /// <param name="data">A byte array of data to be sent.</param>
-        public new async Task SendAsync(byte[] data)
+        public new Task SendAsync(byte[] data)
         {
-            await base.SendAsync(data);
+            return base.SendAsync(data);
         }
 
         /// <summary>
@@ -55,9 +55,9 @@ namespace Sockets.Plugin
         /// <param name="data">A byte array of data to send.</param>
         /// <param name="address">The remote address to which the data should be sent.</param>
         /// <param name="port">The remote port to which the data should be sent.</param>
-        public new async Task SendToAsync(byte[] data, string address, int port)
+        public new Task SendToAsync(byte[] data, string address, int port)
         {
-            await base.SendToAsync(data, address, port);
+            return base.SendToAsync(data, address, port);
         }
     }
 }

--- a/Sockets/Sockets.Implementation.WinRT/UdpSocketMulticastClient.cs
+++ b/Sockets/Sockets.Implementation.WinRT/UdpSocketMulticastClient.cs
@@ -41,10 +41,10 @@ namespace Sockets.Plugin
             }
             else
 #endif
-                await _backingDatagramSocket.BindServiceNameAsync(sn);
+            await _backingDatagramSocket.BindServiceNameAsync(sn);
 
             _backingDatagramSocket.Control.OutboundUnicastHopLimit = (byte) TTL;
-            await Task.Run(() => _backingDatagramSocket.JoinMulticastGroup(hn));
+            _backingDatagramSocket.JoinMulticastGroup(hn);
 
             _multicastAddress = multicastAddress;
             _multicastPort = port;
@@ -55,12 +55,12 @@ namespace Sockets.Plugin
         ///     If a group has not been set, calls will have no effect.
         /// </summary>
         /// <param name="data">A byte array of data to be sent.</param>
-        public async Task SendMulticastAsync(byte[] data)
+        public Task SendMulticastAsync(byte[] data)
         {
             if (_multicastAddress == null)
                 throw new InvalidOperationException("Must join a multicast group before sending.");
 
-            await base.SendToAsync(data, _multicastAddress, _multicastPort);
+            return base.SendToAsync(data, _multicastAddress, _multicastPort);
         }
 
         /// <summary>
@@ -76,9 +76,9 @@ namespace Sockets.Plugin
         /// <summary>
         ///     Removes the <code>UdpSocketMulticastClient</code> from a joined multicast group.
         /// </summary>
-        public async Task DisconnectAsync()
+        public Task DisconnectAsync()
         {
-            await CloseSocketAsync();
+            return CloseSocketAsync();
         }
     }
 }

--- a/Sockets/Sockets.Implementation.WinRT/UdpSocketReceiver.cs
+++ b/Sockets/Sockets.Implementation.WinRT/UdpSocketReceiver.cs
@@ -17,7 +17,7 @@ namespace Sockets.Plugin
         /// <param name="port">The port to listen on. If '0', selection is delegated to the operating system.</param>        
         /// <param name="listenOn">The <code>CommsInterface</code> to listen on. If unspecified, all interfaces will be bound.</param>
         /// <returns></returns>
-        public async Task StartListeningAsync(int port = 0, ICommsInterface listenOn = null)
+        public Task StartListeningAsync(int port = 0, ICommsInterface listenOn = null)
         {
             if (listenOn != null && !listenOn.IsUsable)
                 throw new InvalidOperationException("Cannot listen on an unusable interface. Check the IsUsable property before attemping to bind.");
@@ -27,20 +27,20 @@ namespace Sockets.Plugin
             if (listenOn != null)
             {
                 var adapter = ((CommsInterface) listenOn).NativeNetworkAdapter;
-                await _backingDatagramSocket.BindServiceNameAsync(sn, adapter);
+                return _backingDatagramSocket.BindServiceNameAsync(sn, adapter).AsTask();
             }
             else
 #endif
-                await _backingDatagramSocket.BindServiceNameAsync(sn);
+                return _backingDatagramSocket.BindServiceNameAsync(sn).AsTask();
         }
 
         /// <summary>   
         ///     Unbinds a bound <code>UdpSocketReceiver</code>. Should not be called if the <code>UdpSocketReceiver</code> has not
         ///     yet been unbound.
         /// </summary>
-        public async Task StopListeningAsync()
+        public Task StopListeningAsync()
         {
-            await CloseSocketAsync();
+            return CloseSocketAsync();
         }
 
         /// <summary>
@@ -49,9 +49,9 @@ namespace Sockets.Plugin
         /// <param name="data">A byte array of data to send.</param>
         /// <param name="address">The remote address to which the data should be sent.</param>
         /// <param name="port">The remote port to which the data should be sent.</param>
-        public new async Task SendToAsync(byte[] data, string address, int port)
+        public new Task SendToAsync(byte[] data, string address, int port)
         {
-            await base.SendToAsync(data, address, port);
+            return base.SendToAsync(data, address, port);
         }
     }
 }


### PR DESCRIPTION
Removes unneccessary `await` calls and `async` modifiers for performance and to reduce the opportunity for calling code to deadlock if invoking methods synchronously via `Result` or `Wait`.