### PR TITLE
Add an extension method that allows unifying the Read- and WriteStreams ...

### DIFF
--- a/Sockets/Sockets.Plugin.Abstractions/Extensions/TcpSocketClientExtensions.cs
+++ b/Sockets/Sockets.Plugin.Abstractions/Extensions/TcpSocketClientExtensions.cs
@@ -117,6 +117,18 @@ namespace Sockets.Plugin.Abstractions
         }
         #endregion
 
+        /// <summary>
+        ///  Wraps <see cref="ITcpSocketClient.ReadStream"/> and <see cref="ITcpSocketClient.WriteStream"/> into
+        ///  a single <see cref="System.IO.Stream"/>. This is primarily intended for migrations from existing code
+        ///  that uses <see cref="System.Net.TcpClient.GetStream"/>.
+        /// </summary>
+        /// <param name="client">
+        ///  The instance of <see cref="ITcpSocketClient"/>
+        /// </param>
+        /// <returns>
+        ///  A single stream that wraps <see cref="ITcpSocketClient.ReadStream"/> and
+        ///  <see cref="ITcpSocketClient.WriteStream"/>.
+        /// </returns>
         public static Stream GetStream(this ITcpSocketClient client)
         {
             Contract.Requires(client != null);

--- a/Sockets/Sockets.Plugin.Abstractions/Extensions/TcpSocketClientExtensions.cs
+++ b/Sockets/Sockets.Plugin.Abstractions/Extensions/TcpSocketClientExtensions.cs
@@ -9,7 +9,7 @@ namespace Sockets.Plugin.Abstractions
     public static class TcpSocketClientExtensions
     {
         #region TwoWayStream
-        public class TwoWayStream : Stream
+        private sealed class TwoWayStream : Stream
         {
             private readonly Stream _readStream;
             private readonly Stream _writeStream;

--- a/Sockets/Sockets.Plugin.Abstractions/Extensions/TcpSocketClientExtensions.cs
+++ b/Sockets/Sockets.Plugin.Abstractions/Extensions/TcpSocketClientExtensions.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sockets.Plugin.Abstractions
+{
+    public static class TcpSocketClientExtensions
+    {
+        #region TwoWayStream
+        public class TwoWayStream : Stream
+        {
+            private readonly Stream _readStream;
+            private readonly Stream _writeStream;
+
+            public TwoWayStream(Stream readStream, Stream writeStream)
+            {
+                this._readStream = readStream;
+                this._writeStream = writeStream;
+            }
+
+            public override void Flush()
+            {
+                this._writeStream.Flush();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    if (this._readStream != null)
+                        this._readStream.Dispose();
+
+                    if (this._writeStream != null)
+                        this._writeStream.Dispose();
+
+                }
+
+                base.Dispose(disposing);
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return this._readStream.Read(buffer, offset, count);
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                return this._readStream.ReadAsync(buffer, offset, count, cancellationToken);
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                this._writeStream.Write(buffer, offset, count);
+            }
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                return this._writeStream.WriteAsync(buffer, offset, count, cancellationToken);
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+            
+            public override long Length
+            {
+                get
+                {
+                    throw new NotSupportedException();
+                }
+            }
+
+            public override long Position
+            {
+                get
+                {
+                    throw new NotSupportedException();
+                }
+
+                set
+                {
+                    throw new NotSupportedException();
+                }
+            }
+        
+            public override bool CanRead
+            {
+                get
+                {
+                    return this._readStream.CanRead;
+                }
+            }
+
+            public override bool CanSeek
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
+            public override bool CanWrite
+            {
+                get
+                {
+                    return this._writeStream.CanWrite;
+                }
+            }
+        }
+        #endregion
+
+        public static Stream GetStream(this ITcpSocketClient client)
+        {
+            Contract.Requires(client != null);
+
+            return new TwoWayStream(client.ReadStream, client.WriteStream);
+        }
+    }
+}

--- a/Sockets/Sockets.Plugin.Abstractions/Sockets.Plugin.Abstractions.csproj
+++ b/Sockets/Sockets.Plugin.Abstractions/Sockets.Plugin.Abstractions.csproj
@@ -38,6 +38,7 @@
     <!-- A reference to the entire .NET Framework is automatically included -->
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\TcpSocketClientExtensions.cs" />
     <Compile Include="ICommsInterface.cs" />
     <Compile Include="IUdpSocketMulticastClient.cs" />
     <Compile Include="ITcpSocketClient.cs" />


### PR DESCRIPTION
...of ITcpSocketClient to a single stream. When you migrate from TcpClient and used GetStream, this is probably something you would want.