### PR TITLE
Add SocketException to Abstractions-project

### DIFF
--- a/Sockets/Sockets.Implementation.NET/Extensions/NativeExceptionExtensions.cs
+++ b/Sockets/Sockets.Implementation.NET/Extensions/NativeExceptionExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using PclSocketException = Sockets.Plugin.Abstractions.SocketException;
+using PlatformSocketException = System.Net.Sockets.SocketException;
+
+namespace Sockets.Plugin.Abstractions
+{
+    public static class NativeExceptionExtensions
+    {
+        internal static readonly HashSet<Type> NativeSocketExceptions = new HashSet<Type> { typeof(PlatformSocketException) };
+
+        public static Task WrapNativeSocketExceptions(this Task task)
+        {
+            return task.ContinueWith(
+                t =>
+                {
+                    var ex = t.Exception.InnerException;
+
+                    throw (NativeExceptionExtensions.NativeSocketExceptions.Contains(ex.GetType())) 
+                        ? new PclSocketException(ex)
+                        : ex;
+                },
+                TaskContinuationOptions.OnlyOnFaulted);
+        }
+
+        public static Task<T> WrapNativeSocketExceptions<T>(this Task<T> task)
+        {
+            return task.ContinueWith(
+                t =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        var ex = t.Exception.InnerException;
+
+                        throw (NativeExceptionExtensions.NativeSocketExceptions.Contains(ex.GetType()))
+                            ? new PclSocketException(ex)
+                            : ex;
+                    }
+
+                    return t.Result;
+                }, TaskContinuationOptions.OnlyOnFaulted);
+        }
+    }
+}

--- a/Sockets/Sockets.Implementation.NET/Extensions/NativeExceptionExtensions.cs
+++ b/Sockets/Sockets.Implementation.NET/Extensions/NativeExceptionExtensions.cs
@@ -27,19 +27,14 @@ namespace Sockets.Plugin.Abstractions
 
         public static Task<T> WrapNativeSocketExceptions<T>(this Task<T> task)
         {
-            return task.ContinueWith(
+            return task.ContinueWith<T>(
                 t =>
                 {
-                    if (t.IsFaulted)
-                    {
-                        var ex = t.Exception.InnerException;
+                    var ex = t.Exception.InnerException;
 
-                        throw (NativeExceptionExtensions.NativeSocketExceptions.Contains(ex.GetType()))
-                            ? new PclSocketException(ex)
-                            : ex;
-                    }
-
-                    return t.Result;
+                    throw (NativeExceptionExtensions.NativeSocketExceptions.Contains(ex.GetType()))
+                        ? new PclSocketException(ex)
+                        : ex;
                 }, TaskContinuationOptions.OnlyOnFaulted);
         }
     }

--- a/Sockets/Sockets.Implementation.NET/Sockets.Implementation.NET.csproj
+++ b/Sockets/Sockets.Implementation.NET/Sockets.Implementation.NET.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommsInterfaceNative.cs" />
+    <Compile Include="Extensions\NativeExceptionExtensions.cs" />
     <Compile Include="NetworkExtensions.cs" />
     <Compile Include="CommsInterface.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
@@ -57,14 +57,9 @@ namespace Sockets.Plugin
         /// <param name="secure">True to enable TLS on the socket.</param>
         public async Task ConnectAsync(string address, int port, bool secure = false)
         {
-            try
-            {
-                await _backingTcpClient.ConnectAsync(address, port);
-            }
-            catch(PlatformSocketException ex)
-            {
-                throw new PclSocketException(ex);
-            }
+            await _backingTcpClient
+                .ConnectAsync(address, port)
+                .WrapNativeSocketExceptions();
 
             InitializeWriteStream();
 

--- a/Sockets/Sockets.Implementation.NET/TcpSocketListener.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketListener.cs
@@ -5,6 +5,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Sockets.Plugin.Abstractions;
 
+using PlatformSocketException = System.Net.Sockets.SocketException;
+using PclSocketException = Sockets.Plugin.Abstractions.SocketException;
+
 // ReSharper disable once CheckNamespace
 
 namespace Sockets.Plugin
@@ -54,7 +57,15 @@ namespace Sockets.Plugin
                 _listenCanceller = new CancellationTokenSource();
 
                 _backingTcpListener = new TcpListener(ipAddress, port);
-                _backingTcpListener.Start();
+
+                try
+                {
+                    _backingTcpListener.Start();
+                }
+                catch(PlatformSocketException ex)
+                {
+                    throw new PclSocketException(ex);
+                }
 
                 WaitForConnections(_listenCanceller.Token);
             });
@@ -70,7 +81,16 @@ namespace Sockets.Plugin
                 () =>
                 {
                     _listenCanceller.Cancel();
-                    _backingTcpListener.Stop();
+
+                    try
+                    {
+                        _backingTcpListener.Stop();
+                    }
+                    catch (PlatformSocketException ex)
+                    {
+                        throw new PclSocketException(ex);
+                    }
+                   
                     _backingTcpListener = null;
                 });
         }

--- a/Sockets/Sockets.Implementation.NET/UdpSocketBase.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketBase.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Sockets.Plugin.Abstractions;
 
+using PlatformSocketException = System.Net.Sockets.SocketException;
+using PclSocketException = Sockets.Plugin.Abstractions.SocketException;
 // ReSharper disable once CheckNamespace
 
 namespace Sockets.Plugin
@@ -34,7 +36,15 @@ namespace Sockets.Plugin
                 try
                 {
                     // attempt to read next datagram
-                    msg = await _backingUdpClient.ReceiveAsync();
+                    try
+                    {
+                        msg = await _backingUdpClient.ReceiveAsync();
+                    }
+                    catch(PlatformSocketException ex)
+                    {
+                        throw new PclSocketException(ex);
+                    }
+
                     didReceive = true;
                 }
                 catch
@@ -69,7 +79,14 @@ namespace Sockets.Plugin
         /// <param name="data">A byte array of data to be sent.</param>
         protected Task SendAsync(byte[] data)
         {
-            return _backingUdpClient.SendAsync(data, data.Length);
+            try
+            {
+                return _backingUdpClient.SendAsync(data, data.Length);
+            }
+            catch (PlatformSocketException ex)
+            {
+                throw new PclSocketException(ex);
+            }
         }
 
         /// <summary>
@@ -80,7 +97,14 @@ namespace Sockets.Plugin
         /// <param name="port">The remote port to which the data should be sent.</param>
         protected Task SendToAsync(byte[] data, string address, int port)
         {
-            return _backingUdpClient.SendAsync(data, data.Length, address, port);
+            try
+            {
+                return _backingUdpClient.SendAsync(data, data.Length, address, port);
+            }
+            catch (PlatformSocketException ex)
+            {
+                throw new PclSocketException(ex);
+            }
         }
         
         /// <summary>

--- a/Sockets/Sockets.Implementation.NET/UdpSocketBase.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketBase.cs
@@ -36,15 +36,10 @@ namespace Sockets.Plugin
                 try
                 {
                     // attempt to read next datagram
-                    try
-                    {
-                        msg = await _backingUdpClient.ReceiveAsync();
-                    }
-                    catch(PlatformSocketException ex)
-                    {
-                        throw new PclSocketException(ex);
-                    }
-
+                    msg = await _backingUdpClient
+                        .ReceiveAsync()
+                        .WrapNativeSocketExceptions();
+                    
                     didReceive = true;
                 }
                 catch
@@ -79,14 +74,9 @@ namespace Sockets.Plugin
         /// <param name="data">A byte array of data to be sent.</param>
         protected Task SendAsync(byte[] data)
         {
-            try
-            {
-                return _backingUdpClient.SendAsync(data, data.Length);
-            }
-            catch (PlatformSocketException ex)
-            {
-                throw new PclSocketException(ex);
-            }
+            return _backingUdpClient
+                .SendAsync(data, data.Length)
+                .WrapNativeSocketExceptions();
         }
 
         /// <summary>
@@ -97,14 +87,9 @@ namespace Sockets.Plugin
         /// <param name="port">The remote port to which the data should be sent.</param>
         protected Task SendToAsync(byte[] data, string address, int port)
         {
-            try
-            {
-                return _backingUdpClient.SendAsync(data, data.Length, address, port);
-            }
-            catch (PlatformSocketException ex)
-            {
-                throw new PclSocketException(ex);
-            }
+            return _backingUdpClient
+                .SendAsync(data, data.Length, address, port)
+                .WrapNativeSocketExceptions();
         }
         
         /// <summary>

--- a/Sockets/Sockets.Implementation.NET/UdpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketClient.cs
@@ -32,7 +32,7 @@ namespace Sockets.Plugin
                     EnableBroadcast = true
                 };
             }
-            catch(PlatformSocketException ex)
+            catch (PlatformSocketException ex)
             {
                 throw new PclSocketException(ex);
             }
@@ -48,17 +48,9 @@ namespace Sockets.Plugin
         {
             _messageCanceller = new CancellationTokenSource();
 
-            return Task.Run(() =>
-            {
-                try
-                {
-                    _backingUdpClient.Connect(address, port);
-                }
-                catch(PlatformSocketException ex)
-                {
-                    throw new PclSocketException(ex);
-                }
-            });
+            return Task
+                .Run(() => this._backingUdpClient.Connect(address, port))
+                .WrapNativeSocketExceptions();
         }
 
         /// <summary>

--- a/Sockets/Sockets.Implementation.NET/UdpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketClient.cs
@@ -3,6 +3,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Sockets.Plugin.Abstractions;
 
+using PlatformSocketException = System.Net.Sockets.SocketException;
+using PclSocketException = Sockets.Plugin.Abstractions.SocketException;
+
 // ReSharper disable once CheckNamespace
 
 namespace Sockets.Plugin
@@ -22,10 +25,17 @@ namespace Sockets.Plugin
         /// </summary>
         public UdpSocketClient()
         {
-            _backingUdpClient = new UdpClient
+            try
             {
-                EnableBroadcast = true
-            };
+                _backingUdpClient = new UdpClient
+                {
+                    EnableBroadcast = true
+                };
+            }
+            catch(PlatformSocketException ex)
+            {
+                throw new PclSocketException(ex);
+            }
         }
 
         /// <summary>
@@ -38,7 +48,17 @@ namespace Sockets.Plugin
         {
             _messageCanceller = new CancellationTokenSource();
 
-            return Task.Run(() => _backingUdpClient.Connect(address, port));
+            return Task.Run(() =>
+            {
+                try
+                {
+                    _backingUdpClient.Connect(address, port);
+                }
+                catch(PlatformSocketException ex)
+                {
+                    throw new PclSocketException(ex);
+                }
+            });
         }
 
         /// <summary>

--- a/Sockets/Sockets.Implementation.NET/UdpSocketMulticastClient.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketMulticastClient.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Sockets.Plugin.Abstractions;
 
+using PlatformSocketException = System.Net.Sockets.SocketException;
+using PclSocketException = Sockets.Plugin.Abstractions.SocketException;
 // ReSharper disable once CheckNamespace
 
 namespace Sockets.Plugin
@@ -39,13 +41,31 @@ namespace Sockets.Plugin
 
             var multicastIp = IPAddress.Parse(multicastAddress);
 
-            _backingUdpClient = new UdpClient(bindingEp)
+            try
             {
-                EnableBroadcast = true
-            };
+                _backingUdpClient = new UdpClient(bindingEp)
+                {
+                    EnableBroadcast = true
+                };
+            }
+            catch (PlatformSocketException ex)
+            {
+                throw new PclSocketException(ex);
+            }
+
             _messageCanceller = new CancellationTokenSource();
             
-            await Task.Run(() => _backingUdpClient.JoinMulticastGroup(multicastIp,TTL));
+            await Task.Run(() =>
+            {
+                try
+                {
+                    _backingUdpClient.JoinMulticastGroup(multicastIp, TTL);
+                }
+                catch (PlatformSocketException ex)
+                {
+                    throw new PclSocketException(ex);
+                }
+            });
 
             _multicastAddress = multicastAddress;
             _multicastPort = port;

--- a/Sockets/Sockets.Implementation.NET/UdpSocketMulticastClient.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketMulticastClient.cs
@@ -55,17 +55,9 @@ namespace Sockets.Plugin
 
             _messageCanceller = new CancellationTokenSource();
             
-            await Task.Run(() =>
-            {
-                try
-                {
-                    _backingUdpClient.JoinMulticastGroup(multicastIp, TTL);
-                }
-                catch (PlatformSocketException ex)
-                {
-                    throw new PclSocketException(ex);
-                }
-            });
+            await Task
+                .Run(() => this._backingUdpClient.JoinMulticastGroup(multicastIp, this.TTL))
+                .WrapNativeSocketExceptions();
 
             _multicastAddress = multicastAddress;
             _multicastPort = port;

--- a/Sockets/Sockets.Implementation.NET/UdpSocketReceiver.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketReceiver.cs
@@ -29,27 +29,22 @@ namespace Sockets.Plugin
             if (listenOn != null && !listenOn.IsUsable)
                 throw new InvalidOperationException("Cannot listen on an unusable interface. Check the IsUsable property before attemping to bind.");
 
-            return Task.Run(() =>
-            {
-                var ip = listenOn != null ? ((CommsInterface)listenOn).NativeIpAddress : IPAddress.Any;
-                var ep = new IPEndPoint(ip, port);
-
-                _messageCanceller = new CancellationTokenSource();
-
-                try
+            return Task
+                .Run(() =>
                 {
+                    var ip = listenOn != null ? ((CommsInterface)listenOn).NativeIpAddress : IPAddress.Any;
+                    var ep = new IPEndPoint(ip, port);
+
+                    _messageCanceller = new CancellationTokenSource();
+
                     _backingUdpClient = new UdpClient(ep)
                     {
                         EnableBroadcast = true
                     };
-                }
-                catch(PlatformSocketException ex)
-                {
-                    throw new PclSocketException(ex);
-                }
 
-                RunMessageReceiver(_messageCanceller.Token);
-            });
+                    RunMessageReceiver(_messageCanceller.Token);
+                })
+                .WrapNativeSocketExceptions();
         }
 
         /// <summary>


### PR DESCRIPTION
In PCL-code, there is obviously no access to the platform specific SocketException so it may not be caught. Catching all exceptions is evil, so this branch adds a class called SocketException to the Abstractions-project. It's sole purpose is to wrap instances of the platform specific exception. I did this wrapping for the .net-implementation only for the moment until I have some feedback on this PR.
