### PR TITLE
Method to get the connected interface for a ITcpSocketClient

### DIFF
--- a/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -99,6 +100,17 @@ namespace Sockets.Plugin
                 _secureStream = null;
                 _backingTcpClient = new TcpClient();
             });
+        }
+
+        /// <summary>
+        /// Gets the interface the connection is using.
+        /// </summary>
+        /// <returns>The <see cref="ICommsInterface"/> which represents the interface the connection is using.</returns>
+        public async Task<ICommsInterface> GetConnectedInterfaceAsync()
+        {
+            var ipEndpoint = (IPEndPoint)_backingTcpClient.Client.LocalEndPoint;
+            var interfaces = await CommsInterface.GetAllInterfacesAsync();
+            return interfaces.FirstOrDefault(x => x.NativeIpAddress.Equals(ipEndpoint.Address));
         }
 
         /// <summary>

--- a/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Windows.Networking;
 using Windows.Networking.Sockets;
@@ -70,6 +71,16 @@ namespace Sockets.Plugin
         public Task DisconnectAsync()
         {
             return Task.Run(() => _backingStreamSocket.Dispose());
+        }
+
+        /// <summary>
+        /// Gets the interface the connection is using.
+        /// </summary>
+        /// <returns>The <see cref="ICommsInterface"/> which represents the interface the connection is using.</returns>
+        public async Task<ICommsInterface> GetConnectedInterfaceAsync()
+        {
+            var interfaces = await CommsInterface.GetAllInterfacesAsync();
+            return interfaces.FirstOrDefault(x => x.NativeHostName.IsEqual(_backingStreamSocket.Information.LocalAddress));
         }
 
         /// <summary>

--- a/Sockets/Sockets.Plugin.Abstractions/ITcpSocketClient.cs
+++ b/Sockets/Sockets.Plugin.Abstractions/ITcpSocketClient.cs
@@ -27,6 +27,12 @@ namespace Sockets.Plugin.Abstractions
         Task DisconnectAsync();
 
         /// <summary>
+        /// Gets the interface the connection is using.
+        /// </summary>
+        /// <returns>The <see cref="ICommsInterface"/> which represents the interface the connection is using.</returns>
+        Task<ICommsInterface> GetConnectedInterfaceAsync();
+
+        /// <summary>
         ///     A stream that can be used for receiving data from the remote endpoint.
         /// </summary>
         Stream ReadStream { get; }

--- a/Sockets/Sockets.Plugin/TcpSocketClient.cs
+++ b/Sockets/Sockets.Plugin/TcpSocketClient.cs
@@ -51,6 +51,15 @@ namespace Sockets.Plugin
         }
 
         /// <summary>
+        /// Gets the interface the connection is using.
+        /// </summary>
+        /// <returns>The <see cref="ICommsInterface"/> which represents the interface the connection is using.</returns>
+        public Task<ICommsInterface> GetConnectedInterfaceAsync()
+        {
+            throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
+        }
+
+        /// <summary>
         ///     A stream that can be used for receiving data from the remote endpoint.
         /// </summary>
         public Stream ReadStream


### PR DESCRIPTION
This implements the changes as described in rdavisau/sockets-for-pcl#27.

I used ```GetConnectedInterfaceAsync``` instead of ```GetConnectedInterface``` because all(?) other methods returning ```Task``` have the ```Async``` prefix too.