### PR TITLE
Use the event keyword instead of an auto property

### DIFF
--- a/Sockets/Sockets.Implementation.NET/TcpSocketListener.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketListener.cs
@@ -34,7 +34,7 @@ namespace Sockets.Plugin
         ///     Use the <code>SocketClient</code> property of the <code>TcpSocketListenerConnectEventArgs</code>
         ///     to get a <code>TcpSocketClient</code> representing the connection for sending and receiving data.
         /// </summary>
-        public EventHandler<TcpSocketListenerConnectEventArgs> ConnectionReceived { get; set; }
+        public event EventHandler<TcpSocketListenerConnectEventArgs> ConnectionReceived;
 
         /// <summary>
         ///     Binds the <code>TcpSocketListener</code> to the specified port on all endpoints and listens for TCP connections.

--- a/Sockets/Sockets.Implementation.WinRT/TcpSocketListener.cs
+++ b/Sockets/Sockets.Implementation.WinRT/TcpSocketListener.cs
@@ -33,7 +33,7 @@ namespace Sockets.Plugin
         ///     Use the <code>SocketClient</code> property of the <code>TcpSocketListenerConnectEventArgs</code>
         ///     to get a <code>TcpSocketClient</code> representing the connection for sending and receiving data.
         /// </summary>
-        public EventHandler<TcpSocketListenerConnectEventArgs> ConnectionReceived { get; set; }
+        public event EventHandler<TcpSocketListenerConnectEventArgs> ConnectionReceived;
 
         /// <summary>
         ///     Binds the <code>TcpSocketListener</code> to the specified port on all endpoints and listens for TCP connections.

--- a/Sockets/Sockets.Plugin.Abstractions/ITcpSocketListener.cs
+++ b/Sockets/Sockets.Plugin.Abstractions/ITcpSocketListener.cs
@@ -34,6 +34,6 @@ namespace Sockets.Plugin.Abstractions
         ///     Use the <code>SocketClient</code> property of the <code>TcpSocketListenerConnectEventArgs</code>
         ///     to get a <code>TcpSocketClient</code> representing the connection for sending and receiving data.
         /// </summary>
-        EventHandler<TcpSocketListenerConnectEventArgs> ConnectionReceived { get; set; }
+        event EventHandler<TcpSocketListenerConnectEventArgs> ConnectionReceived;
     }
 }

--- a/Sockets/Sockets.Plugin/TcpSocketListener.cs
+++ b/Sockets/Sockets.Plugin/TcpSocketListener.cs
@@ -61,10 +61,10 @@ namespace Sockets.Plugin
         ///     Use the <code>SocketClient</code> property of the <code>TcpSocketListenerConnectEventArgs</code>
         ///     to get a <code>TcpSocketClient</code> representing the connection for sending and receiving data.
         /// </summary>
-        public EventHandler<TcpSocketListenerConnectEventArgs> ConnectionReceived
+        public event EventHandler<TcpSocketListenerConnectEventArgs> ConnectionReceived
         {
-            get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-            set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+            add { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+            remove { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
         }
 
         /// <summary>


### PR DESCRIPTION
Using and event instead of an auto property in the ITcpSocketListener has some advantages:
 * Only the TcpSocketListener is able to raise the event
 * IntelliSense/ReSharper provide more relevant icons and code completion options
 * http://stackoverflow.com/questions/29155/what-are-the-differences-between-delegates-and-events

EDIT: I just read that you want the pull requests on the dev branch, if you want I can close this PR and rebase it for the dev branch?

EDIT2: The udp classes have the same issues, if you want I could provide the same fix for those too