### PR TITLE
Fix invalid cast exception

### DIFF
--- a/Sockets/Sockets.Implementation.NET/TcpSocketListener.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketListener.cs
@@ -146,7 +146,7 @@ namespace Sockets.Plugin
             if (disposing)
             {
                 if (_backingTcpListener != null)
-                    ((IDisposable)_backingTcpListener).Dispose();
+                    _backingTcpListener.Stop();
             }
         }
         


### PR DESCRIPTION
Disposing a TcpSocketListener on .NET would throw an InvalidCastException because TcpListener doesn't implement IDisposable