### PR TITLE
Connect to Named Service + Timeout

### DIFF
--- a/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
@@ -61,7 +61,8 @@ namespace Sockets.Plugin
                             ? new CancellationTokenSource(timeout).Token
                             : CancellationToken.None;
 
-            //close connection when timeout is invoked
+            // close connection when timeout is invoked
+            // See https://www.symbolsource.org/Public/Metadata/NuGet/Project/CqlSharp/0.34.0.0/Release/.NETFramework,Version%3Dv4.5/CqlSharp/CqlSharp/Network/SocketExtensions.cs?ImageName=CqlSharp
             using (token.Register((cl) => ((TcpClient)cl).Close(), _backingTcpClient))
             {
                 await _backingTcpClient.ConnectAsync(address, port).ConfigureAwait(false);
@@ -95,7 +96,8 @@ namespace Sockets.Plugin
                                 ? new CancellationTokenSource(timeout).Token
                                 : CancellationToken.None;
 
-                //close connection when timeout is invoked
+                // close connection when timeout is invoked
+                // See https://www.symbolsource.org/Public/Metadata/NuGet/Project/CqlSharp/0.34.0.0/Release/.NETFramework,Version%3Dv4.5/CqlSharp/CqlSharp/Network/SocketExtensions.cs?ImageName=CqlSharp
                 using (token.Register((cl) => ((TcpClient)cl).Close(), _backingTcpClient))
                 {
                     await _backingTcpClient.ConnectAsync(address, 80).ConfigureAwait(false);

--- a/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Sockets.Plugin.Abstractions;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 
 namespace Sockets.Plugin
 {
@@ -52,9 +53,20 @@ namespace Sockets.Plugin
         /// <param name="address">The address of the endpoint to connect to.</param>
         /// <param name="port">The port of the endpoint to connect to.</param>
         /// <param name="secure">True to enable TLS on the socket.</param>
-        public async Task ConnectAsync(string address, int port, bool secure = false)
+        /// <param name="timeout">Client specified timout.</param>
+        public async Task ConnectAsync(string address, int port, bool secure = false, int timeout = 0)
         {
-            await _backingTcpClient.ConnectAsync(address, port);
+            //create connection timeout token
+            var token = timeout > 0
+                            ? new CancellationTokenSource(timeout).Token
+                            : CancellationToken.None;
+
+            //close connection when timeout is invoked
+            using (token.Register((cl) => ((TcpClient)cl).Close(), _backingTcpClient))
+            {
+                await _backingTcpClient.ConnectAsync(address, port).ConfigureAwait(false);
+            }
+
             InitializeWriteStream();
             if (secure)
             {
@@ -62,6 +74,43 @@ namespace Sockets.Plugin
                 secureStream.AuthenticateAsClient(address, null, System.Security.Authentication.SslProtocols.Tls, false);
                 _secureStream = secureStream;
             }            
+        }
+
+        /// <summary>
+        ///     Establishes a TCP connection with the service at the specified address/port pair.
+        /// </summary>
+        /// <param name="address">The address of the endpoint to connect to.</param>
+        /// <param name="service">The service of the endpoint to connect to.</param>
+        /// <param name="timeout">Connection timout in msec.</param>
+        /// <param name="secure">True to enable TLS on the socket.</param>
+        /// <param name="timeout">Client specified timout.</param>
+        public async Task ConnectAsync(string address, string service, bool secure = false, int timeout = 0)
+        {
+            var lcService = service.ToLower();
+
+            if (lcService.Equals("http"))
+            {
+                //create connection timeout token
+                var token = timeout > 0
+                                ? new CancellationTokenSource(timeout).Token
+                                : CancellationToken.None;
+
+                //close connection when timeout is invoked
+                using (token.Register((cl) => ((TcpClient)cl).Close(), _backingTcpClient))
+                {
+                    await _backingTcpClient.ConnectAsync(address, 80).ConfigureAwait(false);
+                }
+
+                InitializeWriteStream();
+                if (secure)
+                {
+                    var secureStream = new SslStream(_writeStream, true, (sender, cert, chain, sslPolicy) => ServerValidationCallback(sender, cert, chain, sslPolicy));
+                    secureStream.AuthenticateAsClient(address, null, System.Security.Authentication.SslProtocols.Tls, false);
+                    _secureStream = secureStream;
+                }            
+        }
+            else
+                throw new InvalidOperationException();
         }
 
         #region Secure Sockets Details
@@ -99,6 +148,14 @@ namespace Sockets.Plugin
                 _secureStream = null;
                 _backingTcpClient = new TcpClient();
             });
+        }
+
+        /// <summary>
+        ///     Returns the underlying backingField.
+        /// </summary>
+        public object Socket
+        {
+            get { return _backingTcpClient; }
         }
 
         /// <summary>

--- a/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
@@ -62,7 +62,9 @@ namespace Sockets.Plugin
             var sn = port.ToString();
             var spl = secure ? _secureSocketProtectionLevel : SocketProtectionLevel.PlainSocket;
 
-            //create connection timeout token
+            // create connection timeout token
+            // See https://msdn.microsoft.com/en-us/library/windows/apps/xaml/jj710176.aspx.
+
             var token = timeout > 0
                             ? new CancellationTokenSource(timeout).Token
                             : CancellationToken.None;
@@ -83,7 +85,8 @@ namespace Sockets.Plugin
             var hn = new HostName(address);
             var spl = secure ? _secureSocketProtectionLevel : SocketProtectionLevel.PlainSocket;
 
-            //create connection timeout token
+            // create connection timeout token
+            // See https://msdn.microsoft.com/en-us/library/windows/apps/xaml/jj710176.aspx
             var token = timeout > 0
                             ? new CancellationTokenSource(timeout).Token
                             : CancellationToken.None;

--- a/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Windows.Networking;
 using Windows.Networking.Sockets;
 using Sockets.Plugin.Abstractions;
+using System.Threading;
 
 // ReSharper disable once CheckNamespace
 
@@ -54,13 +55,40 @@ namespace Sockets.Plugin
         /// <param name="address">The address of the endpoint to connect to.</param>
         /// <param name="port">The port of the endpoint to connect to.</param>
         /// <param name="secure">True to enable TLS on the socket.</param>
-        public Task ConnectAsync(string address, int port, bool secure = false)
+        /// <param name="timeout">Client specified timout.</param>
+        public Task ConnectAsync(string address, int port, bool secure = false, int timeout = 0)
         {
             var hn = new HostName(address);
             var sn = port.ToString();
             var spl = secure ? _secureSocketProtectionLevel : SocketProtectionLevel.PlainSocket;
 
-            return _backingStreamSocket.ConnectAsync(hn, sn, spl).AsTask();
+            //create connection timeout token
+            var token = timeout > 0
+                            ? new CancellationTokenSource(timeout).Token
+                            : CancellationToken.None;
+
+            return  _backingStreamSocket.ConnectAsync(hn, sn, spl).AsTask(CancellationToken.None);
+        }
+
+        /// <summary>
+        ///     Establishes a TCP connection with the service at the specified address/port pair.
+        /// </summary>
+        /// <param name="address">The address of the endpoint to connect to.</param>
+        /// <param name="service">The service to connect to.</param>
+        /// <param name="timeout">Connection timout in msec.</param>
+        /// <param name="secure">True to enable TLS on the socket.</param>
+        /// <param name="timeout">Client specified timout.</param>
+        public Task ConnectAsync(string address, string service, bool secure = false, int timeout = 0)
+        {
+            var hn = new HostName(address);
+            var spl = secure ? _secureSocketProtectionLevel : SocketProtectionLevel.PlainSocket;
+
+            //create connection timeout token
+            var token = timeout > 0
+                            ? new CancellationTokenSource(timeout).Token
+                            : CancellationToken.None;
+
+            return _backingStreamSocket.ConnectAsync(hn, service, spl).AsTask(token);
         }
 
         /// <summary>
@@ -70,6 +98,17 @@ namespace Sockets.Plugin
         public Task DisconnectAsync()
         {
             return Task.Run(() => _backingStreamSocket.Dispose());
+        }
+
+        /// <summary>
+        ///     Returns the underlying backingField.
+        /// </summary>
+        public object Socket
+        {
+            get
+            {
+                return _backingStreamSocket;
+            }
         }
 
         /// <summary>

--- a/Sockets/Sockets.Plugin.Abstractions/ITcpSocketClient.cs
+++ b/Sockets/Sockets.Plugin.Abstractions/ITcpSocketClient.cs
@@ -13,12 +13,27 @@ namespace Sockets.Plugin.Abstractions
     public interface ITcpSocketClient : IDisposable
     {
         /// <summary>
+        ///     Returns the underlying backingField.
+        /// </summary>
+        Object Socket { get; }
+
+        /// <summary>
         ///     Establishes a TCP connection with the endpoint at the specified address/port pair.
         /// </summary>
         /// <param name="address">The address of the endpoint to connect to.</param>
         /// <param name="port">The port of the endpoint to connect to.</param>
         /// <param name="secure">Is this socket secure?</param>
-        Task ConnectAsync(string address, int port, bool secure = false);
+        /// <param name="timeout">Client specified timout.</param>
+        Task ConnectAsync(string address, int port, bool secure = false, int timeout = 0);
+
+        /// <summary>
+        ///     Establishes a TCP connection with the service at the specified address/port pair.
+        /// </summary>
+        /// <param name="address">The address of the endpoint to connect to.</param>
+        /// <param name="service">The service to connect to.</param>
+        /// <param name="secure">Is this socket secure?</param>
+        /// <param name="timeout">Client specified timout.</param>
+        Task ConnectAsync(string address, string service, bool secure = false, int timeout = 0);
 
         /// <summary>
         ///     Disconnects from an endpoint previously connected to using <code>ConnectAsync</code>.

--- a/Sockets/Sockets.Plugin/TcpSocketClient.cs
+++ b/Sockets/Sockets.Plugin/TcpSocketClient.cs
@@ -36,9 +36,22 @@ namespace Sockets.Plugin
         /// <param name="address">The address of the endpoint to connect to.</param>
         /// <param name="port">The port of the endpoint to connect to.</param>
         /// <param name="secure">True to enable TLS on the socket.</param>
-        public Task ConnectAsync(string address, int port, bool secure = false)
+        /// <param name="timeout">Client specified timout.</param>
+        public Task ConnectAsync(string address, int port, bool secure = false, int timeout = 0)
         {
             throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
+        }
+
+        /// <summary>
+        ///     Establishes a TCP connection with the service at the specified address/port pair.
+        /// </summary>
+        /// <param name="address">The address of the endpoint to connect to.</param>
+        /// <param name="service">The service of the endpoint to connect to.</param>
+        /// <param name="secure">True to enable TLS on the socket.</param>
+        /// <param name="timeout">Client specified timout.</param>
+        public Task ConnectAsync(string address, string service, bool secure = false, int timeout = 0)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -48,6 +61,14 @@ namespace Sockets.Plugin
         public Task DisconnectAsync()
         {
             throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
+        }
+
+        /// <summary>
+        ///     Returns the underlying backingField.
+        /// </summary>
+        public object Socket
+        {
+            get { throw new NotImplementedException(); }
         }
 
         /// <summary>


### PR DESCRIPTION
Ok, I think I've got the git stuff straightened out. Please review the changes in this pull request for merge consideration into you main project branch. I added a new ConnectAsync() method to connect to a named remote service, i.e. "http", and added support on all ConnectAsync() methods to override the default connect timeout.