### PR TITLE
Add NoDelay property to TcpSocketClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Console.WriteLine("Listening on interface with ip: {0}", firstUsable.IpAddress);
  - On Windows Phone, you will require appropriate permissions in your app manifest. Depending on whether you are listening or sending, this could include a combination of `privateNetworkClientServer`, `internetClient` and/or  `internetClientServer` capabilities. 
  - On Windows Phone/Store, there are restrictions regarding passing traffic over loopback between separate apps (i.e. no IPC) 
  - Binding to specific interfaces is not supported on Windows Phone 8.0 (8.1 is fine). All interfaces will be bound, even if a specific `CommsInterface` is provided. 
+ - On Windows Phone/Store, the NoDelay property of TcpSocketListener has no effect. The implementation does not support this property.
 
 Additional 'higher level' features will likely end up in the [sockethelpers-for-pcl](https://github.com/rdavisau/sockethelpers-for-pcl) project mentioned earlier. 
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Many members of the community have contributed to improving sockets-for-pcl:
  - @jasells (udpclient design considerations)
  - @vbisbest (prelease testing, bugfixes)
  - @1iveowl (udp multicast considerations)
+ - @cts-craig (NoDelay property on TcpSocketClient and TcpSocketListener)
 
 If you have a bugfix or a feature you'd like to add, please open an issue. 
 All pull requests should be opened against the `dev` branch.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Many members of the community have contributed to improving sockets-for-pcl:
  - @jasells (udpclient design considerations)
  - @vbisbest (prelease testing, bugfixes)
  - @1iveowl (udp multicast considerations)
- - @cts-craig (NoDelay property on TcpSocketClient and TcpSocketListener)
+ - @cmjacobs (NoDelay property on TcpSocketClient and TcpSocketListener)
 
 If you have a bugfix or a feature you'd like to add, please open an issue. 
 All pull requests should be opened against the `dev` branch.

--- a/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
@@ -220,6 +220,12 @@ namespace Sockets.Plugin
             get { return RemoteEndpoint.Port; }
         }
 
+        public bool NoDelay
+        {
+            get { return _backingTcpClient.NoDelay; }
+            set { _backingTcpClient.NoDelay = value; }
+        }
+
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>

--- a/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketClient.cs
@@ -220,6 +220,9 @@ namespace Sockets.Plugin
             get { return RemoteEndpoint.Port; }
         }
 
+        /// <summary>
+        /// Enables or disables delay when send or receive buffers are full.
+        /// </summary>
         public bool NoDelay
         {
             get { return _backingTcpClient.NoDelay; }

--- a/Sockets/Sockets.Implementation.NET/TcpSocketListener.cs
+++ b/Sockets/Sockets.Implementation.NET/TcpSocketListener.cs
@@ -103,6 +103,15 @@ namespace Sockets.Plugin
             get { return ((IPEndPoint) (_backingTcpListener.LocalEndpoint)).Port; }
         }
 
+        /// <summary>
+        /// Enables or disables delay when send or receive buffers are full.
+        /// </summary>
+        public bool NoDelay
+        {
+            get { return _backingTcpListener.Server.NoDelay; }
+            set { _backingTcpListener.Server.NoDelay = value; }
+        }
+
 #pragma warning disable 4014
         private void WaitForConnections(CancellationToken cancelToken)
         {

--- a/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.WinRT/TcpSocketClient.cs
@@ -135,6 +135,15 @@ namespace Sockets.Plugin
         }
 
         /// <summary>
+        /// Enables or disables delay when send or receive buffers are full.
+        /// </summary>
+        public bool NoDelay
+        {
+            get { return _backingStreamSocket.Control.NoDelay; }
+            set { _backingStreamSocket.Control.NoDelay = value; }            
+        }
+
+        /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()

--- a/Sockets/Sockets.Implementation.WinRT/TcpSocketListener.cs
+++ b/Sockets/Sockets.Implementation.WinRT/TcpSocketListener.cs
@@ -104,6 +104,15 @@ namespace Sockets.Plugin
         }
 
         /// <summary>
+        /// Enables or disables delay when send or receive buffers are full.
+        /// </summary>
+        public bool NoDelay
+        {
+            get { return false; }
+            set { }
+        }
+
+        /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()

--- a/Sockets/Sockets.Plugin.Abstractions/ITcpSocketClient.cs
+++ b/Sockets/Sockets.Plugin.Abstractions/ITcpSocketClient.cs
@@ -62,6 +62,11 @@ namespace Sockets.Plugin.Abstractions
         ///     The port of the remote endpoint to which the <code>TcpSocketClient</code> is currently connected.
         /// </summary>
         int RemotePort { get; }
+
+        /// <summary>
+        /// Enables or disables delay when send or receive buffers are full.
+        /// </summary>
+        bool NoDelay { get; set; }
     }
 
     public interface IExposeBackingSocket

--- a/Sockets/Sockets.Plugin.Abstractions/ITcpSocketListener.cs
+++ b/Sockets/Sockets.Plugin.Abstractions/ITcpSocketListener.cs
@@ -35,5 +35,10 @@ namespace Sockets.Plugin.Abstractions
         ///     to get a <code>TcpSocketClient</code> representing the connection for sending and receiving data.
         /// </summary>
         event EventHandler<TcpSocketListenerConnectEventArgs> ConnectionReceived;
+
+        /// <summary>
+        /// Enables or disables delay when send or receive buffers are full.
+        /// </summary>
+        bool NoDelay { get; set; }
     }
 }

--- a/Sockets/Sockets.Plugin/TcpSocketClient.cs
+++ b/Sockets/Sockets.Plugin/TcpSocketClient.cs
@@ -105,6 +105,15 @@ namespace Sockets.Plugin
         }
 
         /// <summary>
+        /// Enables or disables delay when send or receive buffers are full.
+        /// </summary>
+        public bool NoDelay
+        {
+            get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+            set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+        }
+
+        /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()

--- a/Sockets/Sockets.Plugin/TcpSocketListener.cs
+++ b/Sockets/Sockets.Plugin/TcpSocketListener.cs
@@ -68,6 +68,15 @@ namespace Sockets.Plugin
         }
 
         /// <summary>
+        /// Enables or disables delay when send or receive buffers are full.
+        /// </summary>
+        public bool NoDelay
+        {
+            get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+            set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+        }
+
+        /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()

--- a/Sockets/Tests/Sockets.Tests/TcpSocketClientTests.cs
+++ b/Sockets/Tests/Sockets.Tests/TcpSocketClientTests.cs
@@ -296,5 +296,14 @@ namespace Sockets.Tests
             return Assert.ThrowsAsync<OperationCanceledException>(()=> sut.ConnectAsync("99.99.99.99", 51234, cancellationToken: cts.Token));
         }
 
+        [Fact]
+        public void TcpSocketClient_NoDelay_CanBeSetAndRead()
+        {
+            var sut = new TcpSocketClient();
+            Assert.False(sut.NoDelay);
+            sut.NoDelay = true;
+            Assert.True(sut.NoDelay);
+        }
+
     }
 }

--- a/Sockets/Tests/Sockets.Tests/TcpSocketClientTests.cs
+++ b/Sockets/Tests/Sockets.Tests/TcpSocketClientTests.cs
@@ -305,5 +305,18 @@ namespace Sockets.Tests
             Assert.True(sut.NoDelay);
         }
 
+        [Fact]
+        public async Task TcpSocketListen_NoDelay_CanBeSetAndRead()
+        {
+#if !WINDOWS_UWP
+            var sut = new TcpSocketListener();
+            var port = PortGranter.GrantPort();
+            await sut.StartListeningAsync(port);
+            Assert.False(sut.NoDelay);
+            sut.NoDelay = true;
+            Assert.True(sut.NoDelay);
+#endif
+        }
+
     }
 }


### PR DESCRIPTION
I saw there was an open issue requesting this (#101). I needed it too so I went ahead and gave it a shot. I added the Unit test and ran it on Windows Desktop. I have not had a chance to try it on other platforms.
