### PR TITLE
Allow Udp Sockets to be specified as exclusive

### DIFF
--- a/Sockets/Sockets.Implementation.NET/UdpSocketClient.cs
+++ b/Sockets/Sockets.Implementation.NET/UdpSocketClient.cs
@@ -21,24 +21,46 @@ namespace Sockets.Plugin
     {
         private CancellationTokenSource _messageCanceller;
 
-        /// <summary>
-        ///     Default constructor for <code>UdpSocketClient.</code>
-        /// </summary>
-        public UdpSocketClient()
-        {
-            try
-            {
-                _backingUdpClient = new UdpClient
-                {
-                    EnableBroadcast = true
-                };
-                ProtectAgainstICMPUnreachable(_backingUdpClient);
-            }
-            catch (PlatformSocketException ex)
-            {
-                throw new PclSocketException(ex);
-            }
-        }
+		/// <summary>
+		///     Default constructor for <code>UdpSocketClient.</code>
+		/// </summary>
+		public UdpSocketClient()
+		{
+			try
+			{
+				_backingUdpClient = new UdpClient
+				{
+					EnableBroadcast = true
+				};
+				ProtectAgainstICMPUnreachable(_backingUdpClient);
+			}
+			catch (PlatformSocketException ex)
+			{
+				throw new PclSocketException(ex);
+			}
+		}
+
+		/// <summary> 
+        ///     Constructor for <code>UdpSocketClient.</code> 
+        /// </summary> 
+        /// <param name="exclusive">Should address use be exclusive?</param> 
+        public UdpSocketClient(bool exclusive) 
+        { 
+          try 
+            { 
+                _backingUdpClient = new UdpClient 
+                { 
+                    EnableBroadcast = true, 
+                    ExclusiveAddressUse = exclusive 
+                }; 
+                _backingUdpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, !exclusive);  
+                ProtectAgainstICMPUnreachable(_backingUdpClient); 
+            } 
+            catch (PlatformSocketException ex) 
+            { 
+                throw new PclSocketException(ex); 
+            }   
+        } 
 
         /// <summary>
         ///     Sets the endpoint at the specified address/port pair as the 'default' target of sent data.

--- a/Sockets/Sockets.Plugin.Abstractions/IUdpSocketMulticastClient.cs
+++ b/Sockets/Sockets.Plugin.Abstractions/IUdpSocketMulticastClient.cs
@@ -16,8 +16,9 @@ namespace Sockets.Plugin.Abstractions
         /// <param name="multicastAddress">The address for the multicast group.</param>
         /// <param name="port">The port for the multicast group.</param>        
         /// <param name="multicastOn">The <code>CommsInterface</code> to multicast on. If unspecified, all interfaces will be bound.</param>
+        /// <param name="exclusive">Should port use be exclusive?</param>
         // <returns></returns>
-        Task JoinMulticastGroupAsync(string multicastAddress, int port, ICommsInterface multicastOn);
+		Task JoinMulticastGroupAsync(string multicastAddress, int port, ICommsInterface multicastOn, bool? exclusive = null); 
 
         /// <summary>
         ///     Removes the <code>UdpSocketMulticastClient</code> from a joined multicast group.

--- a/Sockets/Sockets.Plugin/UdpSocketClient.cs
+++ b/Sockets/Sockets.Plugin/UdpSocketClient.cs
@@ -12,6 +12,15 @@ namespace Sockets.Plugin
     /// </summary>
     public class UdpSocketClient : UdpSocketBase, IUdpSocketClient
     {
+		/// <summary> 
+        ///     Constructor for <code>UdpSocketClient.</code> 
+        /// </summary> 
+        /// <param name="exclusive">Should address use be exclusive?</param> 
+        public UdpSocketClient(bool exclusive) 
+        { 
+            throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); 
+        } 
+ 
         /// <summary>
         ///     Sets the endpoint at the specified address/port pair as the 'default' target of sent data.
         ///     After calling <code>ConnectAsync</code>, use <code>SendAsync</code> to send data to the default target.

--- a/Sockets/Sockets.Plugin/UdpSocketMulticastClient.cs
+++ b/Sockets/Sockets.Plugin/UdpSocketMulticastClient.cs
@@ -17,8 +17,9 @@ namespace Sockets.Plugin
         /// <param name="multicastAddress">The address for the multicast group.</param>
         /// <param name="port">The port for the multicast group.</param>
         /// <param name="multicastOn">The <code>CommsInterface</code> to multicast on. If unspecified, all interfaces will be bound.</param>
+        /// <param name="exclusive">Should address use be exclusive?</param> 
         /// <returns></returns>
-        public Task JoinMulticastGroupAsync(string multicastAddress, int port, ICommsInterface multicastOn = null)
+        public Task JoinMulticastGroupAsync(string multicastAddress, int port, ICommsInterface multicastOn = null, bool? exclusive = null)
         {
             throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
         }


### PR DESCRIPTION
Different platforms have different defaults, resulting in different behaviour.  E.g. on iOS udp connections are exclusive, on android they are shared.  Either could be desired